### PR TITLE
Enhancements and bugfixes for ALMA archive cubes

### DIFF
--- a/characterize/calc_props_from_moments.pro
+++ b/characterize/calc_props_from_moments.pro
@@ -41,7 +41,6 @@ function calc_props_from_moments $
   if n_elements(empty_props) eq 0 then begin
 
      empty_props = add_props_fields(moments)
-
      for i = 0, n_mod-1 do begin
         empty_props = $
            call_function("moments_"+modules[i] $
@@ -169,6 +168,7 @@ function calc_props_from_moments $
                       , astr=astr $
                       , vaxis=vaxis $                      
                       , _extra=extra)
+     
   endfor
 
 ; %&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&

--- a/characterize/cube_to_moments.pro
+++ b/characterize/cube_to_moments.pro
@@ -4,7 +4,7 @@ pro cube_to_moments $
    , assign = assign $
    , inassign = inassign $
    , rms = rms $
-   , inrms = inrms $
+   , rmsfile = rmsfile $
    , hdr = hdr $
    , outfile = outfile $
    , verbose = verbose $
@@ -53,8 +53,8 @@ pro cube_to_moments $
   
   if n_elements(rms) eq 0 then begin
      file_ct  = 0
-     if n_elements(inrms) gt 0 then $
-       file_rms = file_search(inrms, count=file_ct)
+     if n_elements(rmsfile) gt 0 then $
+       file_rms = file_search(rmsfile, count=file_ct)
      if file_ct eq 0 then begin
         message, "Noise cube not found. Not critical.", /info
      endif else begin

--- a/characterize/moments_classic.pro
+++ b/characterize/moments_classic.pro
@@ -68,7 +68,7 @@ function moments_classic $
         props = create_struct(props, "mom2v_extrap", nan)
         props = create_struct(props, "mom2v_unit", "pix")
 
-;       PRINCIPLE AXES CALCULATION
+;       PRINCIPAL AXES CALCULATION
         props = create_struct(props, "mom2maj", nan)
         props = create_struct(props, "mom2maj_extrap", nan)
         props = create_struct(props, "mom2maj_unit", "pix")
@@ -136,7 +136,7 @@ function moments_classic $
         props = create_struct(props, "vrms_extrap_deconv", nan)
         props = create_struct(props, "vrms_unit", "km/s")
 
-;       PRINCIPLE AXIS QUANTITIES
+;       PRINCIPAL AXIS QUANTITIES
         props = create_struct(props, "majrms", nan)
         props = create_struct(props, "majrms_extrap", nan)
         props = create_struct(props, "majrms_extrap_deconv", nan)
@@ -245,10 +245,10 @@ function moments_classic $
      props.mom2v = mom2v[n_elements(mom2v)-1]
      
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-; PRINCIPLE AXES
+; PRINCIPAL AXES
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-; Perform the principle axes decomposition and record those values.
+; Perform the principal axes decomposition and record those values.
 
      ellfit, x=x, y=y, wt=t, posang=posang
 
@@ -280,7 +280,7 @@ function moments_classic $
 
      props.mom2maj = mom2xrot[n_elements(mom2xrot)-1]
      props.mom2min = mom2yrot[n_elements(mom2yrot)-1]
-     
+     stop
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 ; CURVE OF GROWTH EXTRAPOLATION
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -457,7 +457,7 @@ function moments_classic $
         sqrt(props.mom2v_extrap^2 - (1.0*props.chantosig)^2)*props.chanwidth_kms
 
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-; PRINCIPLE AXIS QUANTITIES
+; PRINCIPAL AXIS QUANTITIES
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
      props.majrms = props.mom2maj*props.pcperpix

--- a/characterize/moments_classic.pro
+++ b/characterize/moments_classic.pro
@@ -280,7 +280,7 @@ function moments_classic $
 
      props.mom2maj = mom2xrot[n_elements(mom2xrot)-1]
      props.mom2min = mom2yrot[n_elements(mom2yrot)-1]
-     stop
+
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 ; CURVE OF GROWTH EXTRAPOLATION
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/cpropstoo_example.pro
+++ b/cpropstoo_example.pro
@@ -73,7 +73,7 @@ pro cpropstoo_example
 
 ; Rerun the masking with the cube "inverted" (flipped to negative) in
 ; order to check the stringency of the mask. The number of pixels in
-; the mask here give an estimate of the flase positive rate.
+; the mask here give an estimate of the false positive rate.
 
   make_cprops_mask $
      , infile = "../data/co32_correct.fits" $
@@ -178,6 +178,7 @@ pro cpropstoo_example
      , infile="../data/co32_correct_pbcorr.fits" $
      , inassign="../data/co32_assign_cprops.fits" $
      , outfile="../measurements/co32_moments_cprops.idl" $
+     , rmsfile = "../data/co32_noise.fits" $
      , /verbose           
 
 ; THE CLUMPFIND CASE
@@ -185,6 +186,7 @@ pro cpropstoo_example
      , infile="../data/co32_correct_pbcorr.fits" $
      , inassign="../data/co32_assign_clfind.fits" $
      , outfile="../measurements/co32_moments_clfind.idl" $
+     , rmsfile = "../data/co32_noise.fits" $
      , /verbose           
 
 ; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/cpropstoo_example.pro
+++ b/cpropstoo_example.pro
@@ -201,7 +201,7 @@ pro cpropstoo_example
   moments_to_props $
      , hdrfile="../data/co32_correct_pbcorr.fits" $
      , infile="../measurements/co32_moments_cprops.idl" $
-     , outfile="../measurements/co32_props_cprops.idl" $
+     , idl_file="../measurements/co32_props_cprops.idl" $
      , dist=11.9d6 $
      , /verbose
 
@@ -209,7 +209,7 @@ pro cpropstoo_example
   moments_to_props $
      , hdrfile="../data/co32_correct_pbcorr.fits" $
      , infile="../measurements/co32_moments_clfind.idl" $
-     , outfile="../measurements/co32_props_clfind.idl" $
+     , idl_file="../measurements/co32_props_clfind.idl" $
      , dist=11.9d6 $
      , /verbose
 

--- a/cubes/calc_jtok.pro
+++ b/cubes/calc_jtok.pro
@@ -2,7 +2,8 @@ function calc_jtok, hdr=hdr $
                     , bmaj=bmaj $
                     , bmin=bmin $
                     , restfreq=restfreq $
-                    , aips=aips
+                    , aips=aips $
+                    , pixels_per_beam = pixels_per_beam
 
 
 ;+
@@ -56,6 +57,8 @@ function calc_jtok, hdr=hdr $
      endelse
      if n_elements(restfreq) eq 0 then $
         restfreq = sxpar(hdr, 'RESTFRQ')
+     getrot,hdr,rotation,cdelt
+     pixels_per_beam = 2*!pi*bmaj*bmin/(8*alog(2)) / abs(cdelt[0]*cdelt[1])
   endif
   
   res_deg = sqrt(bmaj*bmin)

--- a/cubes/prep_cube.pro
+++ b/cubes/prep_cube.pro
@@ -180,7 +180,7 @@ pro prep_cube $
               str = strsplit(str, /ext)
               bmaj_deg = float(str[3])/3600
               bmin_deg = float(str[5])/3600
-              bpa_deg = float(str[9])/3600
+              bpa_deg = float(str[9])
               sxaddpar, hdr, "BMAJ", bmaj_deg
               sxaddpar, hdr, "BMIN", bmin_deg
               sxaddpar, hdr, "BPA", bpa_deg

--- a/cubes/prep_cube.pro
+++ b/cubes/prep_cube.pro
@@ -242,8 +242,7 @@ pro prep_cube $
 ; WRITE TO DISK
 ; &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 
-  sxaddpar, hdr, 'CPROCESS', 1.0, 'process_cube applied.'
-  
+  sxaddhist, hdr, 'CPROCESS v1.0 prep_cube applied.'
   writefits, out_file, cube, hdr
 
 end

--- a/cubes/prep_cube.pro
+++ b/cubes/prep_cube.pro
@@ -215,8 +215,8 @@ pro prep_cube $
      if units eq "JY" then begin
 ;       Factor for JY/BEAM
         jtok = calc_jtok(hdr = hdr,pixels_per_beam = ppbeam)
-;       Divide by pixels per beam to get JY/PIX
-        jtok /= ppbeam
+;       Multiply by pixels per beam to get JY/PIX conversion fac.
+        jtok *= ppbeam
         cube *= jtok
         sxaddpar, hdr, "BUNIT", "K"
      endif

--- a/cubes/prep_cube.pro
+++ b/cubes/prep_cube.pro
@@ -242,7 +242,7 @@ pro prep_cube $
 ; WRITE TO DISK
 ; &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 
-  sxaddhist, hdr, 'CPROCESS v1.0 prep_cube applied.'
+  sxaddhist, 'CPROCESS v1.0 prep_cube applied.', hdr
   writefits, out_file, cube, hdr
 
 end

--- a/cubes/prep_cube.pro
+++ b/cubes/prep_cube.pro
@@ -243,6 +243,8 @@ pro prep_cube $
 ; &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 
   sxaddhist, 'CPROCESS v1.0 prep_cube applied.', hdr
-  writefits, out_file, cube, hdr
+  if sxpar(hdr,'BITPIX') eq -32 then  $
+     writefits, out_file, float(cube), hdr else $
+        writefits, out_file, cube, hdr
 
 end

--- a/cubes/prep_cube.pro
+++ b/cubes/prep_cube.pro
@@ -67,9 +67,9 @@ pro prep_cube $
 ; &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
 
 ;    PUT IN A USER SUPPLIED LINE NAME
-     if n_elements(line_name) gt 0 then begin
-        sxaddpar, hdr, 'LINE', line_name, after='OBJECT'
-     endif
+  if n_elements(line_name) gt 0 then begin
+     sxaddpar, hdr, 'LINE', line_name, after='OBJECT'
+  endif
 
   if keyword_set(skip_vel) eq 0 then begin
 
@@ -99,22 +99,32 @@ pro prep_cube $
 
 ;    TRY TO ENFORCE KM/S
      cdelt3 = sxpar(hdr, 'CDELT3')
-     if keyword_set(ms_to_kms) or abs(cdelt3) gt 1e2 then begin
-        sxaddpar, hdr, 'CDELT3', cdelt3/1e3        
-        crval3 = sxpar(hdr, 'CRVAL3')
-        sxaddpar, hdr, 'CRVAL3', crval3/1e3        
-        sxaddpar, hdr, 'CTYPE3', 'VRAD' ; assume radio velocity
-        sxaddpar, hdr, 'CUNIT3', 'KM/S', after='CTYPE3'
-        ; ctype3 = strupcase(strcompress(sxpar(hdr, 'CTYPE3'), /rem))
-        ; if ctype3 eq 'M/S' then begin
-        ;    sxaddpar, hdr, 'CTYPE3', 'KM/S'
-        ; endif
-     endif
-
-     if n_elements(new_ctype3) gt 0 then begin
-        sxaddpar, hdr, 'CTYPE3', new_ctype3
-     endif
-     
+     ctype3 = strupcase(strcompress(sxpar(hdr, 'CTYPE3'),/rem))
+     if ctype3 eq "FREQ" then begin
+        message,'Original cube in frequency units... attempting conversion.',/con
+        c_kms = 2.99792458d5
+        center_velocity = (sxpar(hdr,'RESTFRQ')-sxpar(hdr,'CRVAL3'))/sxpar(hdr,'RESTFRQ')*c_kms
+        deltav_kms = sxpar(hdr,'CDELT3')/sxpar(hdr,'RESTFRQ')*c_kms
+        sxaddpar,hdr,'CRVAL3',center_velocity
+        sxaddpar,hdr,'CDELT3',deltav_kms
+        sxaddpar,hdr,'CTYPE3','VRAD-F2V'
+        sxaddpar,hdr,'CUNIT3','KM/S',after='CTYPE3'
+     endif else begin
+        if keyword_set(ms_to_kms) or abs(cdelt3) gt 1e2 then begin
+           sxaddpar, hdr, 'CDELT3', cdelt3/1e3        
+           crval3 = sxpar(hdr, 'CRVAL3')
+           sxaddpar, hdr, 'CRVAL3', crval3/1e3        
+           sxaddpar, hdr, 'CTYPE3', 'VRAD' ; assume radio velocity
+           sxaddpar, hdr, 'CUNIT3', 'KM/S', after='CTYPE3'
+                                ; ctype3 = strupcase(strcompress(sxpar(hdr, 'CTYPE3'), /rem))
+                                ; if ctype3 eq 'M/S' then begin
+                                ;    sxaddpar, hdr, 'CTYPE3', 'KM/S'
+                                ; endif
+        endif
+        if n_elements(new_ctype3) gt 0 then begin
+           sxaddpar, hdr, 'CTYPE3', new_ctype3
+        endif
+     endelse 
   endif
   
 ; &%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%
@@ -154,14 +164,28 @@ pro prep_cube $
            if ct gt 0 then begin
               str = hdr[max(ind)]
               str = strsplit(str, /ext)
-              bmaj_deg = float(str[4])*3600
-              bmin_deg = float(str[6])*3600
+              bmaj_deg = float(str[4])/3600
+              bmin_deg = float(str[6])/3600
               bpa_deg = float(str[8])
               
               sxaddpar, hdr, "BMAJ", bmaj_deg
-              sxaddpar, hdr, "BPA", bmin_deg
-              sxaddpar, hdr, "BMIN", bpa_deg
+              sxaddpar, hdr, "BMIN", bmin_deg
+              sxaddpar, hdr, "BPA", bpa_deg
            endif
+;          TRAP SOME FLAVORS OF ALMA HEADERS
+           ind = where(strpos(hdr,'restoration:') gt 0 and $
+                       strpos(hdr,'(arcsec)') gt 0, ct)
+           if ct gt 0 then begin
+              str = hdr[max(ind)]
+              str = strsplit(str, /ext)
+              bmaj_deg = float(str[3])/3600
+              bmin_deg = float(str[5])/3600
+              bpa_deg = float(str[9])/3600
+              sxaddpar, hdr, "BMAJ", bmaj_deg
+              sxaddpar, hdr, "BMIN", bmin_deg
+              sxaddpar, hdr, "BPA", bpa_deg
+           endif
+
         endif else begin
 
 ;          TRAP CASE WHERE ONLY BMAJ IS SPECIFIED
@@ -185,6 +209,14 @@ pro prep_cube $
         sxaddpar, hdr, "BUNIT", "K"
      if total(units eq ["JY/BEAM","JY/BM"]) then begin
         jtok = calc_jtok(hdr=hdr)
+        cube *= jtok
+        sxaddpar, hdr, "BUNIT", "K"
+     endif
+     if units eq "JY" then begin
+;       Factor for JY/BEAM
+        jtok = calc_jtok(hdr = hdr,pixels_per_beam = ppbeam)
+;       Divide by pixels per beam to get JY/PIX
+        jtok /= ppbeam
         cube *= jtok
         sxaddpar, hdr, "BUNIT", "K"
      endif


### PR DESCRIPTION
I put in a few enhancements to `prep_cube`, caught a few errors, and likely introduced some of my own.  The only thing I realized after the fact is that I made an API change in `cube_to_moments` that might cause problems for you.  My intention was to make it consistent with the earlier routines in the `cpropstoo_example` file, but no good deed goes unpunished.  If you'd like to me to revert, I can do that too.